### PR TITLE
Replace deprecated type hints.

### DIFF
--- a/kumade/builder.py
+++ b/kumade/builder.py
@@ -2,18 +2,18 @@
 
 import shutil
 from pathlib import Path
-from typing import Any, List, Optional, Protocol
+from typing import Any, Optional, Protocol
 
 from kumade.task import Task, TaskName, TaskProcedure
 
 
 class ArgsConfigurable(Protocol):
-    def set_args(self, args: List[Any]) -> None:
+    def set_args(self, args: list[Any]) -> None:
         ...  # pragma: no cover
 
 
 class DependenciesConfigurable(Protocol):
-    def set_dependencies(self, dependencies: List[TaskName]) -> None:
+    def set_dependencies(self, dependencies: list[TaskName]) -> None:
         ...  # pragma: no cover
 
 
@@ -25,14 +25,14 @@ class HelpConfigurable(Protocol):
 class TaskBuilder(ArgsConfigurable, DependenciesConfigurable, HelpConfigurable):
     def __init__(self, name: str) -> None:
         self.__name = name
-        self.__args: List[Any] = []
-        self.__dependencies: List[TaskName] = []
+        self.__args: list[Any] = []
+        self.__dependencies: list[TaskName] = []
         self.__help: Optional[str] = None
 
-    def set_args(self, args: List[Any]) -> None:
+    def set_args(self, args: list[Any]) -> None:
         self.__args = args
 
-    def set_dependencies(self, dependencies: List[TaskName]) -> None:
+    def set_dependencies(self, dependencies: list[TaskName]) -> None:
         self.__dependencies = dependencies
 
     def set_help(self, help: str) -> None:
@@ -51,13 +51,13 @@ class TaskBuilder(ArgsConfigurable, DependenciesConfigurable, HelpConfigurable):
 class FileTaskBuilder(ArgsConfigurable, DependenciesConfigurable):
     def __init__(self, path: Path) -> None:
         self.__path = path
-        self.__args: List[Any] = []
-        self.__dependencies: List[TaskName] = []
+        self.__args: list[Any] = []
+        self.__dependencies: list[TaskName] = []
 
-    def set_args(self, args: List[Any]) -> None:
+    def set_args(self, args: list[Any]) -> None:
         self.__args = args
 
-    def set_dependencies(self, dependencies: List[TaskName]) -> None:
+    def set_dependencies(self, dependencies: list[TaskName]) -> None:
         self.__dependencies = dependencies
 
     def build(self, procedure: TaskProcedure) -> Task:
@@ -87,16 +87,16 @@ class FileTaskBuilder(ArgsConfigurable, DependenciesConfigurable):
 class CleanTaskBuilder(DependenciesConfigurable, HelpConfigurable):
     def __init__(self, name: str) -> None:
         self.__name = name
-        self.__dependencies: List[TaskName] = []
+        self.__dependencies: list[TaskName] = []
         self.__help: Optional[str] = None
 
-    def set_dependencies(self, dependencies: List[TaskName]) -> None:
+    def set_dependencies(self, dependencies: list[TaskName]) -> None:
         self.__dependencies = dependencies
 
     def set_help(self, help: str) -> None:
         self.__help = help
 
-    def build(self, clean_paths: List[Path]) -> Task:
+    def build(self, clean_paths: list[Path]) -> Task:
         def clean_procedure(*paths: Path) -> None:
             for path in paths:
                 if path.exists():

--- a/kumade/cli.py
+++ b/kumade/cli.py
@@ -4,7 +4,6 @@ import importlib.util
 import sys
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import List, Tuple
 
 import kumade
 from kumade.manager import TaskManager
@@ -82,7 +81,7 @@ class CLI:
         shows_tasks: bool,
         shows_all: bool,
         verbose: bool,
-        targets: List[str],
+        targets: list[str],
     ) -> None:
         self.__manager = manager
         self.__kumadefile = kumadefile
@@ -108,7 +107,7 @@ class CLI:
                 raise RuntimeError("No target is specified.")
             self.__targets.append(default_task_name)
 
-        targets_to_run: List[TaskName] = []
+        targets_to_run: list[TaskName] = []
         for target in self.__targets:
             if self.__manager.find(target):
                 targets_to_run.append(target)
@@ -141,7 +140,7 @@ class CLI:
         len_of_names = [len(str(task.name)) for task in tasks if task.has_help]
         name_width = max(len_of_names) + 2
 
-        def get_sort_key(task: Task) -> Tuple[int, str]:
+        def get_sort_key(task: Task) -> tuple[int, str]:
             if task.has_help:
                 priority = 0
             elif isinstance(task.name, str):

--- a/kumade/decorator.py
+++ b/kumade/decorator.py
@@ -1,7 +1,8 @@
 # Decorator to create and register task
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from kumade.builder import (
     ArgsConfigurable,
@@ -85,7 +86,7 @@ def depend(*dependencies: Optional[TaskName]) -> Callable:
     def decorator(
         base: Union[TaskProcedure, TaskConfig[DependenciesConfigurable]]
     ) -> TaskConfig[DependenciesConfigurable]:
-        deps: List[TaskName] = [dep for dep in dependencies if dep is not None]
+        deps: list[TaskName] = [dep for dep in dependencies if dep is not None]
         return TaskConfig(base, lambda builder: builder.set_dependencies(deps))
 
     return decorator

--- a/kumade/manager.py
+++ b/kumade/manager.py
@@ -1,6 +1,6 @@
 # Task manager
 
-from typing import Dict, List, Optional
+from typing import Optional
 
 from kumade.task import Task, TaskName
 
@@ -15,7 +15,7 @@ class TaskManager:
         return cls.__instance
 
     def __init__(self) -> None:
-        self.__task: Dict[TaskName, Task] = {}
+        self.__task: dict[TaskName, Task] = {}
         self.__default_task_name: Optional[str] = None
 
     @property
@@ -35,8 +35,8 @@ class TaskManager:
     def find(self, name: TaskName) -> Optional[Task]:
         return self.__task.get(name)
 
-    def get_all_tasks(self) -> List[Task]:
+    def get_all_tasks(self) -> list[Task]:
         return list(self.__task.values())
 
-    def get_tasks_described_with_help(self) -> List[Task]:
+    def get_tasks_described_with_help(self) -> list[Task]:
         return list(filter(lambda task: task.has_help, self.__task.values()))

--- a/kumade/runner.py
+++ b/kumade/runner.py
@@ -1,7 +1,6 @@
 # Task runner
 
 from pathlib import Path
-from typing import List, Set
 
 from kumade.manager import TaskManager
 from kumade.task import Task, TaskName
@@ -12,14 +11,14 @@ class TaskRunner:
         self.__manager = TaskManager.get_instance()
         self.__verbose = verbose
 
-    def run(self, targets: List[TaskName]) -> None:
+    def run(self, targets: list[TaskName]) -> None:
         queue = self.__create_queue(targets)
         self.__execute_queue(queue)
 
-    def __create_queue(self, targets: List[TaskName]) -> List[Task]:
-        queue: List[Task] = []
-        visited: Set[TaskName] = set()
-        added: Set[TaskName] = set()
+    def __create_queue(self, targets: list[TaskName]) -> list[Task]:
+        queue: list[Task] = []
+        visited: set[TaskName] = set()
+        added: set[TaskName] = set()
         for target in targets:
             self.__create_queue_recursively(target, queue, visited, added)
         return queue
@@ -27,9 +26,9 @@ class TaskRunner:
     def __create_queue_recursively(
         self,
         target: TaskName,
-        queue: List[Task],
-        visited: Set[TaskName],
-        added: Set[TaskName],
+        queue: list[Task],
+        visited: set[TaskName],
+        added: set[TaskName],
     ) -> None:
         if target in visited:
             if target in added:
@@ -53,7 +52,7 @@ class TaskRunner:
         queue.append(task)
         added.add(target)
 
-    def __execute_queue(self, queue: List[Task]) -> None:
+    def __execute_queue(self, queue: list[Task]) -> None:
         for task in queue:
             if self.__verbose:
                 print(f"[Task] {task.name}")

--- a/kumade/task.py
+++ b/kumade/task.py
@@ -1,8 +1,9 @@
 # Task
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Optional, Union
 
 TaskName = Union[str, Path]
 TaskProcedure = Callable[..., None]
@@ -12,8 +13,8 @@ TaskProcedure = Callable[..., None]
 class Task:
     name: TaskName
     procedure: TaskProcedure
-    args: List[Any]
-    dependencies: List[TaskName]
+    args: list[Any]
+    dependencies: list[TaskName]
     help: Optional[str]
 
     @property

--- a/kumade/utility.py
+++ b/kumade/utility.py
@@ -1,7 +1,7 @@
 # Utility to create and register task
 
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from kumade.builder import CleanTaskBuilder, FileTaskBuilder
 from kumade.manager import TaskManager
@@ -15,8 +15,8 @@ def set_default(name: str) -> None:
 
 def clean(
     name: str,
-    paths: List[Path],
-    dependencies: Optional[List[TaskName]] = None,
+    paths: list[Path],
+    dependencies: Optional[list[TaskName]] = None,
     help: Optional[str] = None,
 ) -> None:
     builder = CleanTaskBuilder(name)
@@ -32,7 +32,7 @@ def clean(
 
 def directory(
     path: Path,
-    dependencies: Optional[List[TaskName]] = None,
+    dependencies: Optional[list[TaskName]] = None,
 ) -> None:
     builder = FileTaskBuilder(path)
 


### PR DESCRIPTION
Some type hints (`typing.List`, `typing.Dict`, `typing.Set`, `typing.Callable`) have become deprecated since Python 3.9.
I've replaced these deprecated type hints.