### PR TITLE
Enable to specify configuration from command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ To format, execute `kumade format`.
 
 To lint, execute `kumade lint`.
 
+### Unit test
+
+To run unit test, execute `kumade test`.
+
+If you want verbose output, execute `kumade test_verbose=true test`.
+
+If you want to run each test file, execute `kumade test_each=true path/to/test_file.py`
+
 ### Coverage
 
-To measure coverage and report it, execute `kumade report_coverage`.
+To measure coverage and report it, execute `kumade coverage`.

--- a/kumade/__init__.py
+++ b/kumade/__init__.py
@@ -1,7 +1,18 @@
 __version__ = "0.1.0"
 
 from kumade.decorator import bind_args, depend, file, help, task
-from kumade.utility import clean, directory, set_default
+from kumade.utility import (
+    add_bool_config,
+    add_config,
+    add_float_config,
+    add_int_config,
+    add_path_config,
+    add_str_config,
+    clean,
+    directory,
+    get_config,
+    set_default,
+)
 
 __all__ = [
     "task",
@@ -12,4 +23,11 @@ __all__ = [
     "set_default",
     "clean",
     "directory",
+    "add_config",
+    "add_bool_config",
+    "add_int_config",
+    "add_float_config",
+    "add_str_config",
+    "add_path_config",
+    "get_config",
 ]

--- a/kumade/config.py
+++ b/kumade/config.py
@@ -1,0 +1,206 @@
+# Configuration
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+Converter = Callable[[str], T]
+
+
+@dataclass(frozen=True)
+class ConfigItem(Generic[T]):
+    """
+    Configuration item.
+
+    Attributes
+    ----------
+    name : str
+        Name of item.
+    converter : Converter[T]
+        Convert function from str to type of item value.
+    default_value : T
+        Default value.
+    help : str
+        Description of item.
+    """
+
+    name: str
+    converter: Converter[T]
+    default_value: T
+    help: str
+
+
+class ConfigRegistry:
+    """
+    Configuration registry.
+    """
+
+    __instance: Optional["ConfigRegistry"] = None
+
+    @classmethod
+    def get_instance(cls) -> "ConfigRegistry":
+        """
+        Return the singleton instance of configuration registry.
+
+        Returns
+        -------
+        registry : ConfigRegistry
+            The instance of configuration registry.
+        """
+        if cls.__instance is None:
+            cls.__instance = cls()
+        return cls.__instance
+
+    def __init__(self) -> None:
+        self.__items: dict[str, ConfigItem] = {}
+
+    def add_item(self, item: ConfigItem) -> None:
+        """
+        Add a configuration item.
+
+        Parameters
+        ----------
+        item : ConfigItem
+            Configuration item to be added.
+
+        Raises
+        ------
+        RuntimeError
+            If a configuration item with the same name has already been added.
+        """
+        name = item.name
+        if name in self.__items:
+            raise RuntimeError(f"Configuration item {name} already exists.")
+        self.__items[name] = item
+
+    def get_all_items(self) -> list[ConfigItem]:
+        """
+        Return all configuration items.
+
+        Returns
+        -------
+        items : list[ConfigItem]
+            List of all configuration items.
+        """
+        return list(self.__items.values())
+
+    def get_confirmed_values(self, values: dict[str, str]) -> dict[str, Any]:
+        """
+        Get confirmed configuration values with specified values.
+
+        Parameters
+        ----------
+        values : dict[str, str]
+            User specified values for configuration items.
+
+        Returns
+        -------
+        confirmed_values : dict[str, str]
+            Confirmed configuration values.
+
+        Raises
+        ------
+        RuntimeError
+            If the specified item is not in configuration items.
+        """
+        for name in values:
+            if name not in self.__items:
+                raise RuntimeError(f"There is no configuration item named {name}.")
+
+        confirmed_values: dict[str, Any] = {}
+
+        for name, item in self.__items.items():
+            if name in values:
+                confirmed_values[name] = item.converter(values[name])
+            else:
+                confirmed_values[name] = item.default_value
+
+        return confirmed_values
+
+
+class Config:
+    """
+    Confirmed configuration.
+    """
+
+    __instance: Optional["Config"] = None
+
+    @classmethod
+    def get_instance(cls) -> "Config":
+        """
+        Return the singleton instance of configuration.
+
+        Returns
+        -------
+        config : Config
+            The instance of configuration.
+
+        Raises
+        ------
+        RuntimeError
+            If the configuration is not confirmed.
+        """
+        if cls.__instance is None:
+            raise RuntimeError("Configuration is not confirmed.")
+        return cls.__instance
+
+    @classmethod
+    def set(cls, values: dict[str, Any]) -> None:
+        """
+        Set confirmed configuration values.
+
+        Parameters
+        ----------
+        values : dict[str, Any]
+            Confirmed configuration values.
+
+        Raises
+        ------
+        RuntimeError
+            If the configuration is already set.
+        """
+        if cls.__instance is not None:
+            raise RuntimeError("Configuration is already set.")
+        cls.__instance = cls(values)
+
+    def __init__(self, values: dict[str, Any]) -> None:
+        """
+        Parameters
+        ----------
+        values : dict[str, Any]
+            Confirmed configuration values.
+        """
+        self.__values = values
+
+    def get(self, name: str) -> Any:
+        """
+        Get a configuration value.
+
+        Parameters
+        ----------
+        name : str
+            Name of item to get.
+
+        Returns
+        -------
+        value : Any
+            Value of item.
+
+        Raises
+        ------
+        RuntimeError
+            If the name is not in configuration items.
+        """
+        if name not in self.__values:
+            raise RuntimeError(f"There is no configuration item named {name}.")
+        return self.__values[name]
+
+    def __getattr__(self, name: str) -> Any:
+        """Alias for get()"""
+        return self.get(name)
+
+    def __getitem__(self, name: str) -> Any:
+        """Alias for get()"""
+        return self.get(name)

--- a/kumade/utility.py
+++ b/kumade/utility.py
@@ -1,9 +1,10 @@
-# Utility to create and register task
+# Utility to create and register task, define and get configuration.
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypeVar
 
 from kumade.builder import CleanTaskBuilder, FileTaskBuilder
+from kumade.config import Config, ConfigItem, ConfigRegistry, Converter
 from kumade.manager import TaskManager
 from kumade.task import TaskName
 
@@ -74,3 +75,143 @@ def directory(
 
     new_task = builder.build(lambda path: path.mkdir(parents=True))
     TaskManager.get_instance().register(new_task)
+
+
+T = TypeVar("T")
+
+
+def add_config(
+    name: str,
+    converter: Converter[T],
+    default_value: T,
+    help: str,
+) -> None:
+    """
+    Add a configuration item.
+
+    Parameters
+    ----------
+    name : str
+        Name of item.
+    converter : Converter[T]
+        Convert function from str to type of item value.
+    default_value : T
+        Default value.
+    help : str
+        Description of item.
+    """
+    item = ConfigItem(name, converter, default_value, help)
+    ConfigRegistry.get_instance().add_item(item)
+
+
+def _str_to_bool(value: str) -> bool:
+    value = value.lower()
+    if value == "true":
+        return True
+    elif value == "false":
+        return False
+    else:
+        raise RuntimeError(f"Can't convert '{value}' to bool.")
+
+
+def add_bool_config(name: str, help: str, default_value: bool = False) -> None:
+    """
+    Add a bool configuration item.
+
+    Parameters
+    ----------
+    name : str
+        Name of item.
+    help : str
+        Description of item.
+    default_value : bool, default False
+        Default value.
+    """
+    item = ConfigItem(name, _str_to_bool, default_value, help)
+    ConfigRegistry.get_instance().add_item(item)
+
+
+def add_int_config(name: str, help: str, default_value: int = 0) -> None:
+    """
+    Add an int configuration item.
+
+    Parameters
+    ----------
+    name : str
+        Name of item.
+    help : str
+        Description of item.
+    default_value : int, default 0
+        Default value.
+    """
+    item = ConfigItem(name, int, default_value, help)
+    ConfigRegistry.get_instance().add_item(item)
+
+
+def add_float_config(name: str, help: str, default_value: float = 0.0) -> None:
+    """
+    Add a float configuration item.
+
+    Parameters
+    ----------
+    name : str
+        Name of item.
+    help : str
+        Description of item.
+    default_value : float, default 0.0
+        Default value.
+    """
+    item = ConfigItem(name, float, default_value, help)
+    ConfigRegistry.get_instance().add_item(item)
+
+
+def add_str_config(name: str, help: str, default_value: str = "") -> None:
+    """
+    Add a string configuration item.
+
+    Parameters
+    ----------
+    name : str
+        Name of item.
+    help : str
+        Description of item.
+    default_value : str, default ""
+        Default value.
+    """
+    item = ConfigItem(name, str, default_value, help)
+    ConfigRegistry.get_instance().add_item(item)
+
+
+def add_path_config(name: str, help: str, default_value: Path = Path()) -> None:
+    """
+    Add a path configuration item.
+
+    Parameters
+    ----------
+    name : str
+        Name of item.
+    help : str
+        Description of item.
+    default_value : Path, default current directory.
+        Default value.
+    """
+    item = ConfigItem(name, Path, default_value, help)
+    ConfigRegistry.get_instance().add_item(item)
+
+
+def get_config() -> Config:
+    """
+    Get confirmed configuration.
+    Note that this method can only be used in task procedure.
+
+    Returns
+    -------
+    config : Config
+        Confirmed configuration.
+
+    Raises
+    ------
+    RuntimeError
+        If the configuration is not confirmed.
+    """
+    return Config.get_instance()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,63 @@
+from contextlib import contextmanager
+from typing import Generator, Optional
+from unittest import TestCase
+
+from kumade.config import Config
+
+
+@contextmanager
+def set_config_instance(instance: Optional[Config]) -> Generator[None, None, None]:
+    # Save original instance
+    org_instance = Config._Config__instance  # type: ignore
+    try:
+        Config._Config__instance = instance  # type: ignore
+        yield
+    finally:
+        # Restore original instance
+        Config._Config__instance = org_instance  # type: ignore
+
+
+class TestConfig(TestCase):
+    def test_get_instance(self) -> None:
+        instance = Config({"item1": 1, "item2": True})
+        with set_config_instance(instance):
+            config = Config.get_instance()
+            another = Config.get_instance()
+            self.assertEqual(config, another)
+
+    def test_get_instance_before_set(self) -> None:
+        with set_config_instance(None):
+            with self.assertRaises(RuntimeError):
+                Config.get_instance()
+
+    def test_set(self) -> None:
+        with set_config_instance(None):
+            Config.set({"item1": 1, "item2": "test"})
+            config = Config.get_instance()
+            self.assertEqual(config.get("item1"), 1)
+            self.assertEqual(config.get("item2"), "test")
+
+    def test_set_again(self) -> None:
+        with set_config_instance(None):
+            Config.set({"item1": 1, "item2": "test"})
+            with self.assertRaises(RuntimeError):
+                Config.set({"item3": False, "item4": 0.0})
+
+    def test_get(self) -> None:
+        config = Config({"item1": 1, "item2": "test"})
+
+        self.assertEqual(config.get("item1"), 1)
+        self.assertEqual(config.get("item2"), "test")
+
+        # access via attribute
+        self.assertEqual(config.item1, 1)
+        self.assertEqual(config.item2, "test")
+
+        # access via key
+        self.assertEqual(config["item1"], 1)
+        self.assertEqual(config["item2"], "test")
+
+    def test_get_with_not_added_item(self) -> None:
+        config = Config({"item1": 1, "item2": "test"})
+        with self.assertRaises(RuntimeError):
+            config.get("item0")

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -1,0 +1,78 @@
+from unittest import TestCase
+
+from kumade.config import ConfigItem, ConfigRegistry
+
+
+class TestConfigRegistry(TestCase):
+    def test_get_instance(self) -> None:
+        registry = ConfigRegistry.get_instance()
+        another = ConfigRegistry.get_instance()
+        self.assertEqual(registry, another)
+
+    def test_add_item_and_get_all_items(self) -> None:
+        registry = ConfigRegistry()
+
+        item1 = ConfigItem("item1", int, 0, "Item 1.")
+        item2 = ConfigItem("item2", int, 0, "Item 2.")
+
+        registry.add_item(item1)
+        registry.add_item(item2)
+
+        all_items = registry.get_all_items()
+        self.assertEqual(len(all_items), 2)
+        self.assertIn(item1, all_items)
+        self.assertIn(item2, all_items)
+
+    def test_add_item_with_same_item_name(self) -> None:
+        registry = ConfigRegistry()
+
+        item = ConfigItem("item", int, 0, "Item.")
+        another = ConfigItem("item", int, 0, "Another Item.")
+        assert item != another
+
+        registry.add_item(item)
+        with self.assertRaises(RuntimeError):
+            registry.add_item(another)
+
+    def test_get_confirmed_values(self) -> None:
+        registry = ConfigRegistry()
+
+        int_item = ConfigItem("count", int, 0, "Count.")
+        float_item = ConfigItem("threshold", float, 0.0, "Threshold.")
+        str_item = ConfigItem("name", lambda s: s, "Taro", "Name.")
+
+        registry.add_item(int_item)
+        registry.add_item(float_item)
+        registry.add_item(str_item)
+
+        confirmed_values = registry.get_confirmed_values({})
+        self.assertEqual(len(confirmed_values), 3)
+        self.assertIn("count", confirmed_values)
+        self.assertEqual(confirmed_values["count"], 0)
+        self.assertIn("threshold", confirmed_values)
+        self.assertEqual(confirmed_values["threshold"], 0.0)
+        self.assertIn("name", confirmed_values)
+        self.assertEqual(confirmed_values["name"], "Taro")
+
+        user_specified = {"count": "10", "name": "Jiro"}
+        confirmed_values = registry.get_confirmed_values(user_specified)
+        self.assertEqual(len(confirmed_values), 3)
+        self.assertIn("count", confirmed_values)
+        self.assertEqual(confirmed_values["count"], 10)
+        self.assertIn("threshold", confirmed_values)
+        self.assertEqual(confirmed_values["threshold"], 0.0)
+        self.assertIn("name", confirmed_values)
+        self.assertEqual(confirmed_values["name"], "Jiro")
+
+    def test_get_confirmed_values_with_not_added_item(self) -> None:
+        registry = ConfigRegistry()
+
+        item0 = ConfigItem("item0", int, 0, "Item 0.")
+        item1 = ConfigItem("item1", int, 0, "Item 1.")
+
+        registry.add_item(item0)
+        registry.add_item(item1)
+
+        user_specified = {"item1": "10", "item2": "20"}
+        with self.assertRaises(RuntimeError):
+            registry.get_confirmed_values(user_specified)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -79,7 +79,7 @@ class TestTaskManager(TestCase):
         self.assertIn(task2, all_tasks)
         self.assertIn(task3, all_tasks)
 
-    def test_tasks_described_with_help(self) -> None:
+    def test_get_tasks_described_with_help(self) -> None:
         manager = TaskManager()
 
         task1 = TaskBuilder("task1").build(MagicMock())

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -3,8 +3,21 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
+from kumade.config import Config, ConfigItem, ConfigRegistry
 from kumade.manager import TaskManager
-from kumade.utility import clean, directory, set_default
+from kumade.utility import (
+    _str_to_bool,
+    add_bool_config,
+    add_config,
+    add_float_config,
+    add_int_config,
+    add_path_config,
+    add_str_config,
+    clean,
+    directory,
+    get_config,
+    set_default,
+)
 
 
 class TestUtility(TestCase):
@@ -78,3 +91,142 @@ class TestUtility(TestCase):
                 # check mkdir() is not called if it already exists.
                 # (if mkdir() is called again, an error will occur.)
                 registered.run()
+
+    def test_add_config(self) -> None:
+        registry = ConfigRegistry()
+        with patch("kumade.config.ConfigRegistry.get_instance", return_value=registry):
+            converter = lambda s: [s]  # noqa: E731
+            default_value: list[str] = []
+            item: ConfigItem[list[str]] = ConfigItem(
+                "test", converter, default_value, "Test item."
+            )
+
+            all_items = registry.get_all_items()
+            self.assertNotIn(item, all_items)
+
+            add_config("test", converter, default_value, "Test item.")
+
+            all_items = registry.get_all_items()
+            self.assertIn(item, all_items)
+
+            confirmed_values = registry.get_confirmed_values({})
+            self.assertDictEqual(confirmed_values, {"test": []})
+
+            confirmed_values = registry.get_confirmed_values({"test": "hoge"})
+            self.assertDictEqual(confirmed_values, {"test": ["hoge"]})
+
+    def test_add_bool_config(self) -> None:
+        registry = ConfigRegistry()
+        with patch("kumade.config.ConfigRegistry.get_instance", return_value=registry):
+            item = ConfigItem("bool", _str_to_bool, False, "Bool item.")
+
+            all_items = registry.get_all_items()
+            self.assertNotIn(item, all_items)
+
+            add_bool_config("bool", "Bool item.")
+
+            all_items = registry.get_all_items()
+            self.assertIn(item, all_items)
+
+            confirmed_values = registry.get_confirmed_values({})
+            self.assertDictEqual(confirmed_values, {"bool": False})
+
+            # test converter
+
+            confirmed_values = registry.get_confirmed_values({"bool": "True"})
+            self.assertDictEqual(confirmed_values, {"bool": True})
+
+            confirmed_values = registry.get_confirmed_values({"bool": "true"})
+            self.assertDictEqual(confirmed_values, {"bool": True})
+
+            confirmed_values = registry.get_confirmed_values({"bool": "False"})
+            self.assertDictEqual(confirmed_values, {"bool": False})
+
+            confirmed_values = registry.get_confirmed_values({"bool": "false"})
+            self.assertDictEqual(confirmed_values, {"bool": False})
+
+            with self.assertRaises(RuntimeError):
+                registry.get_confirmed_values({"bool": "hoge"})
+
+    def test_add_int_config(self) -> None:
+        registry = ConfigRegistry()
+        with patch("kumade.config.ConfigRegistry.get_instance", return_value=registry):
+            item = ConfigItem("int", int, 1, "Int item.")
+
+            all_items = registry.get_all_items()
+            self.assertNotIn(item, all_items)
+
+            add_int_config("int", "Int item.", default_value=1)
+
+            all_items = registry.get_all_items()
+            self.assertIn(item, all_items)
+
+            confirmed_values = registry.get_confirmed_values({})
+            self.assertDictEqual(confirmed_values, {"int": 1})
+
+            confirmed_values = registry.get_confirmed_values({"int": "10"})
+            self.assertDictEqual(confirmed_values, {"int": 10})
+
+    def test_add_float_config(self) -> None:
+        registry = ConfigRegistry()
+        with patch("kumade.config.ConfigRegistry.get_instance", return_value=registry):
+            item = ConfigItem("float", float, 1.0, "Float item.")
+
+            all_items = registry.get_all_items()
+            self.assertNotIn(item, all_items)
+
+            add_float_config("float", "Float item.", default_value=1.0)
+
+            all_items = registry.get_all_items()
+            self.assertIn(item, all_items)
+
+            confirmed_values = registry.get_confirmed_values({})
+            self.assertDictEqual(confirmed_values, {"float": 1.0})
+
+            confirmed_values = registry.get_confirmed_values({"float": "3.14"})
+            self.assertDictEqual(confirmed_values, {"float": 3.14})
+
+    def test_add_str_config(self) -> None:
+        registry = ConfigRegistry()
+        with patch("kumade.config.ConfigRegistry.get_instance", return_value=registry):
+            item = ConfigItem("str", str, "dummy", "Str item.")
+
+            all_items = registry.get_all_items()
+            self.assertNotIn(item, all_items)
+
+            add_str_config("str", "Str item.", default_value="dummy")
+
+            all_items = registry.get_all_items()
+            self.assertIn(item, all_items)
+
+            confirmed_values = registry.get_confirmed_values({})
+            self.assertDictEqual(confirmed_values, {"str": "dummy"})
+
+            confirmed_values = registry.get_confirmed_values({"str": "value"})
+            self.assertDictEqual(confirmed_values, {"str": "value"})
+
+    def test_add_path_config(self) -> None:
+        registry = ConfigRegistry()
+        with patch("kumade.config.ConfigRegistry.get_instance", return_value=registry):
+            default_path = Path("tmp")
+            item = ConfigItem("path", Path, default_path, "Path item.")
+
+            all_items = registry.get_all_items()
+            self.assertNotIn(item, all_items)
+
+            add_path_config("path", "Path item.", default_value=default_path)
+
+            all_items = registry.get_all_items()
+            self.assertIn(item, all_items)
+
+            confirmed_values = registry.get_confirmed_values({})
+            self.assertDictEqual(confirmed_values, {"path": default_path})
+
+            confirmed_values = registry.get_confirmed_values({"path": "hoge"})
+            self.assertDictEqual(confirmed_values, {"path": Path("hoge")})
+
+    def test_get_config(self) -> None:
+        config = Config({"name": "Taro", "age": 10})
+        with patch("kumade.config.Config.get_instance", return_value=config):
+            ret = get_config()
+            self.assertEqual(ret, config)


### PR DESCRIPTION
I've enabled to specify configuration from command line.

To add a configuration item, use the functions `kumade.add_config()`, `kumade.add_bool_config()`, and so on.
The value of the added configuration item can be specified from the command line like `config=value`, and can be referred to from the Config object obtained with the `kumade.get_config()` function.

I also added examples using configuration.
It enabled you to test with verbose output and to run each test file.

This change fixes the issue #2 . close #2 